### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/yardenshoham/minio-config-cli/security/code-scanning/1](https://github.com/yardenshoham/minio-config-cli/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read repository contents (e.g., to fetch code and dependencies), we will set `contents: read` as the minimal required permission. This ensures the workflow does not have unnecessary write permissions, reducing the risk of misuse.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
