### PR TITLE
Add OIDC authentication for the import command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 chart/charts
+debug/

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Inspired by
 
 # Usage
 
-```bash
-minio-config-cli import MINIO_URL ACCESS_KEY SECRET_KEY --import-file-location=CONFIG_FILE1 --import-file-location=CONFIG_FILE2
-```
+The `import` subcommand takes the MinIO URL as a positional argument and
+authenticates using either static access-key/secret-key credentials or OIDC
+(AssumeRoleWithWebIdentity).
+
+## Static credentials
 
 Assuming you have a MinIO server running on `http://localhost:9000` with an
 admin access key of `minioadmin`, a secret key of `minioadmin`, and a config
@@ -22,8 +24,30 @@ file at `/tmp/config.yaml`, you can import the config file with the following
 command:
 
 ```bash
-minio-config-cli import http://localhost:9000 minioadmin minioadmin --import-file-location=/tmp/config.yaml
+minio-config-cli import http://localhost:9000 \
+    --access-key=minioadmin --secret-key=minioadmin \
+    --import-file-location=/tmp/config.yaml
 ```
+
+## OIDC credentials
+
+```bash
+minio-config-cli import https://minio.example.com \
+    --oidc-issuer-url=https://keycloak.example.com/realms/minio \
+    --oidc-client-id=minio-client \
+    --oidc-client-secret=$OIDC_CLIENT_SECRET \
+    --import-file-location=/tmp/config.yaml
+```
+
+For a password grant, pass `--username` and `--password`
+instead of `--oidc-client-secret`. The grant is auto-detected from the
+flags but can be forced with `--grant-type=client-credentials` or
+`--grant-type=password`.
+
+All flags fall back to environment variables when unset:
+`MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`,
+`OIDC_CLIENT_SECRET`, `OIDC_EXTRA_SCOPES` (comma-separated), `OIDC_GRANT_TYPE`,
+`OIDC_USERNAME`, `OIDC_PASSWORD`.
 
 # Config Files
 
@@ -125,7 +149,8 @@ docker run --rm -p 9000:9000 -p 9001:9001 minio/minio server /data --console-add
 before performing the following command:
 
 ```bash
-minio-config-cli import http://localhost:9000 minioadmin minioadmin \
+minio-config-cli import http://localhost:9000 \
+    --access-key=minioadmin --secret-key=minioadmin \
     --import-file-location=./testdata/config.yaml
 ```
 
@@ -148,7 +173,8 @@ Available docker tags
 ```shell script
 docker run \
     -v <your config path>:/config \
-    yardenshoham/minio-config-cli:latest import http://host.docker.internal:9000 minioadmin minioadmin \
+    yardenshoham/minio-config-cli:latest import http://host.docker.internal:9000 \
+        --access-key=minioadmin --secret-key=minioadmin \
         --import-file-location=/config/*
 ```
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -44,6 +44,17 @@ extraEnvVars:
 
 Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
 
+### Authentication
+
+Two mutually-exclusive modes are supported:
+
+- **Static**: set `accessKey` and `secretKey`.
+- **OIDC** (AssumeRoleWithWebIdentity): set `oidcIssuerUrl`, `oidcClientId`, and one of:
+  - `oidcClientSecret` (client-credentials grant), or
+  - `username` + `password` (password grant), optionally with `oidcClientSecret` for confidential clients.
+
+For production, place sensitive values (`secretKey`, `oidcClientSecret`, `password`) in a `Secret` and reference it via `extraEnvVarsSecret` rather than inlining them in `values.yaml`.
+
 ### Sidecars
 
 If additional init containers are needed in the same pod, they can be defined using the `initContainers` parameter. Here is an example:
@@ -65,8 +76,15 @@ Learn more about [init containers](https://kubernetes.io/docs/concepts/workloads
 | `global.imagePullSecrets`                           | Global Docker registry secret names as an array                                             | `[]`             |
 | `useHooks`                                          | Use Helm hooks to install the job                                                           | `false`          |
 | `url`                                               | MinIO URL                                                                                   | REQUIRED         |
-| `accessKey`                                         | MinIO access key                                                                            | REQUIRED         |
-| `secretKey`                                         | MinIO secret key                                                                            | REQUIRED         |
+| `accessKey`                                         | MinIO access key (static auth; mutually exclusive with OIDC)                                | `null`           |
+| `secretKey`                                         | MinIO secret key (static auth; mutually exclusive with OIDC)                                | `null`           |
+| `oidcIssuerUrl`                                     | OIDC issuer URL, e.g. `https://keycloak.example.com/realms/minio`                           | `null`           |
+| `oidcClientId`                                      | OIDC client ID                                                                              | `null`           |
+| `oidcClientSecret`                                  | OIDC client secret (prefer setting via `extraEnvVarsSecret`)                                | `null`           |
+| `oidcExtraScopes`                                   | Extra OIDC scopes added on top of `openid`                                                  | `[]`             |
+| `grantType`                                         | OIDC grant type: `auto`, `password`, or `client-credentials`                                | `null`           |
+| `username`                                          | Username for the OIDC password grant                                                        | `null`           |
+| `password`                                          | Password for the OIDC password grant (prefer setting via `extraEnvVarsSecret`)              | `null`           |
 | `config`                                            | minio-config-cli config file as a YAML/JSON object                                          | `{}`             |
 | `extraConfig`                                       | Additional optional minio-config-cli config file as a YAML/JSON object                      | `{}`             |
 | `nameOverride`                                      | String to partially override common.names.name                                              | `""`             |

--- a/chart/templates/job.yaml
+++ b/chart/templates/job.yaml
@@ -47,11 +47,45 @@ spec:
           args:
             - import
             - {{ required "A MinIO URL is required" .Values.url | quote }}
-            - {{ required "A MinIO access key is required" .Values.accessKey | quote }}
-            - {{ required "A MinIO secret key is required" .Values.secretKey | quote }}
             - --import-file-location=/configs
           {{- end }}
           env:
+            {{- if .Values.accessKey }}
+            - name: MINIO_ACCESS_KEY
+              value: {{ .Values.accessKey | quote }}
+            {{- end }}
+            {{- if .Values.secretKey }}
+            - name: MINIO_SECRET_KEY
+              value: {{ .Values.secretKey | quote }}
+            {{- end }}
+            {{- if .Values.oidcIssuerUrl }}
+            - name: OIDC_ISSUER_URL
+              value: {{ .Values.oidcIssuerUrl | quote }}
+            {{- end }}
+            {{- if .Values.oidcClientId }}
+            - name: OIDC_CLIENT_ID
+              value: {{ .Values.oidcClientId | quote }}
+            {{- end }}
+            {{- if .Values.oidcClientSecret }}
+            - name: OIDC_CLIENT_SECRET
+              value: {{ .Values.oidcClientSecret | quote }}
+            {{- end }}
+            {{- if .Values.oidcExtraScopes }}
+            - name: OIDC_EXTRA_SCOPES
+              value: {{ join "," .Values.oidcExtraScopes | quote }}
+            {{- end }}
+            {{- if .Values.grantType }}
+            - name: OIDC_GRANT_TYPE
+              value: {{ .Values.grantType | quote }}
+            {{- end }}
+            {{- if .Values.username }}
+            - name: OIDC_USERNAME
+              value: {{ .Values.username | quote }}
+            {{- end }}
+            {{- if .Values.password }}
+            - name: OIDC_PASSWORD
+              value: {{ .Values.password | quote }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,16 @@
 useHooks: false
 url: null
+# Static credentials (leave both null when using OIDC).
 accessKey: null
 secretKey: null
+# OIDC credentials (leave all null when using static).
+oidcIssuerUrl: null
+oidcClientId: null
+oidcClientSecret: null
+oidcExtraScopes: []
+grantType: null
+username: null
+password: null
 config: {}
 extraConfig: {}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,43 +1,66 @@
 package cmd
 
 import (
+	"cmp"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/minio/madmin-go/v4"
 	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/cobra"
+	"github.com/yardenshoham/minio-config-cli/pkg/auth"
 	"github.com/yardenshoham/minio-config-cli/pkg/reconciliation"
 )
 
 func newImportCmd() *cobra.Command {
-	var importFileLocations []string
-	var dryRun bool
-	var importCmd = &cobra.Command{
-		Use:     "import MINIO_URL ACCESS_KEY SECRET_KEY",
-		Short:   "Import configuration from the specified files",
-		Example: "minio-config-cli import http://localhost:9000 minioadmin minioadmin --import-file-location=config.yaml",
-		Args:    cobra.ExactArgs(3),
+	var (
+		importFileLocations []string
+		dryRun              bool
+		cfg                 auth.Config
+	)
+	importCmd := &cobra.Command{
+		Use:   "import MINIO_URL",
+		Short: "Import configuration from the specified files",
+		Example: `minio-config-cli import http://localhost:9000 \
+    --access-key=minioadmin --secret-key=minioadmin \
+    --import-file-location=config.yaml
+
+minio-config-cli import https://minio.example.com \
+    --oidc-issuer-url=https://keycloak.example.com/realms/minio \
+    --oidc-client-id=minio-client \
+    --oidc-client-secret=$OIDC_CLIENT_SECRET \
+    --import-file-location=config.yaml`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			url, err := url.Parse(args[0])
+			applyEnvFallback(&cfg)
+
+			parsed, err := url.Parse(args[0])
 			if err != nil {
 				return fmt.Errorf("failed to parse minio url: %w", err)
 			}
-			secure := url.Scheme == "https"
-			creds := credentials.NewStaticV4(args[1], args[2], "")
-			madminClient, err := madmin.NewWithOptions(url.Host, &madmin.Options{
+			if parsed.Host == "" {
+				return fmt.Errorf("failed to parse minio url: missing host in %q", args[0])
+			}
+			secure := parsed.Scheme == "https"
+			stsEndpoint := parsed.Scheme + "://" + parsed.Host
+
+			creds, err := auth.BuildCredentials(cmd.Context(), stsEndpoint, cfg)
+			if err != nil {
+				return fmt.Errorf("failed to build credentials: %w", err)
+			}
+			madminClient, err := madmin.NewWithOptions(parsed.Host, &madmin.Options{
 				Secure: secure,
 				Creds:  creds,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create madmin client: %w", err)
 			}
-			minioClient, err := minio.New(url.Host, &minio.Options{
+			minioClient, err := minio.New(parsed.Host, &minio.Options{
 				Creds:  creds,
 				Secure: secure,
 			})
@@ -85,14 +108,62 @@ func newImportCmd() *cobra.Command {
 	}
 	const importFileLocationsFlagName = "import-file-location"
 	importCmd.Flags().StringSliceVarP(&importFileLocations, importFileLocationsFlagName, "i", []string{}, "Import configuration from the specified files")
-	err := importCmd.MarkFlagRequired(importFileLocationsFlagName)
-	if err != nil {
+	if err := importCmd.MarkFlagRequired(importFileLocationsFlagName); err != nil {
 		panic(err)
 	}
-	err = importCmd.MarkFlagFilename(importFileLocationsFlagName, "yaml", "yml", "json")
-	if err != nil {
+	if err := importCmd.MarkFlagFilename(importFileLocationsFlagName, "yaml", "yml", "json"); err != nil {
 		panic(err)
 	}
 	importCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Don't actually modify resources in the MinIO server")
+
+	// Static auth flags.
+	importCmd.Flags().StringVar(&cfg.AccessKey, "access-key", "", "MinIO access key (env: MINIO_ACCESS_KEY)")
+	importCmd.Flags().StringVar(&cfg.SecretKey, "secret-key", "", "MinIO secret key (env: MINIO_SECRET_KEY)")
+
+	// OIDC auth flags.
+	importCmd.Flags().StringVar(&cfg.OIDCIssuerURL, "oidc-issuer-url", "", "OIDC issuer URL, e.g. https://keycloak.example.com/realms/minio (env: OIDC_ISSUER_URL)")
+	importCmd.Flags().StringVar(&cfg.OIDCClientID, "oidc-client-id", "", "OIDC client ID (env: OIDC_CLIENT_ID)")
+	importCmd.Flags().StringVar(&cfg.OIDCClientSecret, "oidc-client-secret", "", "OIDC client secret (env: OIDC_CLIENT_SECRET)")
+	importCmd.Flags().StringSliceVar(&cfg.OIDCExtraScopes, "oidc-extra-scope", nil, "Extra OIDC scopes added on top of 'openid' (env: OIDC_EXTRA_SCOPES, comma-separated)")
+	importCmd.Flags().StringVar(&cfg.GrantType, "grant-type", "", "OIDC grant type: auto|password|client-credentials (env: OIDC_GRANT_TYPE)")
+	importCmd.Flags().StringVar(&cfg.Username, "username", "", "Username for the password grant (env: OIDC_USERNAME)")
+	importCmd.Flags().StringVar(&cfg.Password, "password", "", "Password for the password grant (env: OIDC_PASSWORD)")
+
+	// Mode mixing is validated centrally in auth.BuildCredentials
+	// (auth.ErrMixedModes), which also catches the env-var case that cobra's
+	// MarkFlagsMutuallyExclusive cannot see.
+
 	return importCmd
+}
+
+// applyEnvFallback fills empty fields of cfg from environment variables.
+// Explicit flags always win because cfg has already been populated by cobra.
+func applyEnvFallback(cfg *auth.Config) {
+	cfg.AccessKey = cmp.Or(cfg.AccessKey, os.Getenv("MINIO_ACCESS_KEY"))
+	cfg.SecretKey = cmp.Or(cfg.SecretKey, os.Getenv("MINIO_SECRET_KEY"))
+	cfg.OIDCIssuerURL = cmp.Or(cfg.OIDCIssuerURL, os.Getenv("OIDC_ISSUER_URL"))
+	cfg.OIDCClientID = cmp.Or(cfg.OIDCClientID, os.Getenv("OIDC_CLIENT_ID"))
+	cfg.OIDCClientSecret = cmp.Or(cfg.OIDCClientSecret, os.Getenv("OIDC_CLIENT_SECRET"))
+	cfg.GrantType = cmp.Or(cfg.GrantType, os.Getenv("OIDC_GRANT_TYPE"))
+	cfg.Username = cmp.Or(cfg.Username, os.Getenv("OIDC_USERNAME"))
+	cfg.Password = cmp.Or(cfg.Password, os.Getenv("OIDC_PASSWORD"))
+	if len(cfg.OIDCExtraScopes) == 0 {
+		cfg.OIDCExtraScopes = parseCSVEnv("OIDC_EXTRA_SCOPES")
+	}
+}
+
+// parseCSVEnv returns the trimmed, non-empty comma-separated values of the
+// given env var, or nil if the variable is empty/unset.
+func parseCSVEnv(name string) []string {
+	v := os.Getenv(name)
+	if v == "" {
+		return nil
+	}
+	var out []string
+	for s := range strings.SplitSeq(v, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/yardenshoham/minio-config-cli/pkg/auth"
 )
 
 func TestImportCmd(t *testing.T) {
@@ -20,9 +22,63 @@ func TestImportCmd(t *testing.T) {
 		{
 			name: "invalid minio url",
 			args: []string{
-				"invalid-url",
-				"minioadmin",
-				"minioadmin",
+				"://bad",
+				"--access-key=minioadmin",
+				"--secret-key=minioadmin",
+				"--import-file-location=../testdata/config.yaml",
+			},
+		},
+		{
+			name: "no credentials configured",
+			args: []string{
+				"http://localhost:9000",
+				"--import-file-location=../testdata/config.yaml",
+			},
+		},
+		{
+			name: "static missing secret key",
+			args: []string{
+				"http://localhost:9000",
+				"--access-key=minioadmin",
+				"--import-file-location=../testdata/config.yaml",
+			},
+		},
+		{
+			name: "static and oidc flags mixed",
+			args: []string{
+				"http://localhost:9000",
+				"--access-key=minioadmin",
+				"--secret-key=minioadmin",
+				"--oidc-issuer-url=https://issuer.example.com",
+				"--oidc-client-id=client",
+				"--import-file-location=../testdata/config.yaml",
+			},
+		},
+		{
+			name: "oidc missing client id",
+			args: []string{
+				"http://localhost:9000",
+				"--oidc-issuer-url=https://issuer.example.com",
+				"--import-file-location=../testdata/config.yaml",
+			},
+		},
+		{
+			name: "password grant missing username",
+			args: []string{
+				"http://localhost:9000",
+				"--oidc-issuer-url=https://issuer.example.com",
+				"--oidc-client-id=client",
+				"--grant-type=password",
+				"--import-file-location=../testdata/config.yaml",
+			},
+		},
+		{
+			name: "client-credentials grant missing client secret",
+			args: []string{
+				"http://localhost:9000",
+				"--oidc-issuer-url=https://issuer.example.com",
+				"--oidc-client-id=client",
+				"--grant-type=client-credentials",
 				"--import-file-location=../testdata/config.yaml",
 			},
 		},
@@ -30,8 +86,8 @@ func TestImportCmd(t *testing.T) {
 			name: "non-existent file",
 			args: []string{
 				"http://localhost:9000",
-				"minioadmin",
-				"minioadmin",
+				"--access-key=minioadmin",
+				"--secret-key=minioadmin",
 				"--import-file-location=doesnotexistiamsure.yaml",
 			},
 		},
@@ -39,8 +95,8 @@ func TestImportCmd(t *testing.T) {
 			name: "malformed config",
 			args: []string{
 				"http://localhost:9000",
-				"minioadmin",
-				"minioadmin",
+				"--access-key=minioadmin",
+				"--secret-key=minioadmin",
 				"--import-file-location=../testdata/malformed/config.yaml",
 			},
 		},
@@ -54,4 +110,25 @@ func TestImportCmd(t *testing.T) {
 			require.Error(t, importCmd.Execute())
 		})
 	}
+}
+
+// TestImportCmd_EnvVarFallback verifies that MINIO_ACCESS_KEY and
+// MINIO_SECRET_KEY env vars are picked up when no --access-key/--secret-key
+// flags are passed. We use a nonexistent import path so the test stays
+// offline: with env fallback working, validation passes and the command
+// fails when it tries to open the file (fs.ErrNotExist).
+func TestImportCmd_EnvVarFallback(t *testing.T) {
+	t.Setenv("MINIO_ACCESS_KEY", "ak")
+	t.Setenv("MINIO_SECRET_KEY", "sk")
+
+	importCmd := newImportCmd()
+	importCmd.SetArgs([]string{
+		"http://localhost:9000",
+		"--import-file-location=doesnotexistiamsure.yaml",
+	})
+	err := importCmd.Execute()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, auth.ErrNoCredentials)
+	require.NotErrorIs(t, err, auth.ErrIncompleteConfig)
+	require.ErrorIs(t, err, fs.ErrNotExist)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/minio/minio-go/v7 v7.2.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
+	github.com/stillya/testcontainers-keycloak v0.3.7
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/minio v0.42.0
+	golang.org/x/oauth2 v0.30.0
 	k8s.io/api v0.35.4
 )
 
@@ -175,7 +177,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260421165255-392afab6f40e // indirect

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stillya/testcontainers-keycloak v0.3.7 h1:PTuzw6WTLRPqjowgVuO0t3P6epyMsJZOcFg0YFZkmjU=
+github.com/stillya/testcontainers-keycloak v0.3.7/go.mod h1:PCRhS4GKuj2nWVYPNXTBKuh56n6r7Y2NBfjajmTSidY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,242 @@
+// Package auth builds *credentials.Credentials values for the MinIO
+// clients used by minio-config-cli. It supports both static MinIO
+// access-key/secret-key credentials and OIDC-backed STS credentials
+// (AssumeRoleWithWebIdentity) using either the client-credentials or
+// resource-owner password grant.
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// Grant types accepted in Config.GrantType.
+const (
+	GrantAuto              = "auto"
+	GrantPassword          = "password"
+	GrantClientCredentials = "client-credentials"
+)
+
+// Sentinel errors returned (wrapped) by BuildCredentials so callers can
+// classify configuration problems without string matching.
+var (
+	// ErrMixedModes is returned when both static and OIDC fields are set.
+	ErrMixedModes = errors.New("auth: cannot mix static and OIDC credentials")
+	// ErrNoCredentials is returned when no authentication mode is configured.
+	ErrNoCredentials = errors.New("auth: no credentials configured")
+	// ErrIncompleteConfig is returned when a chosen mode is missing required fields.
+	ErrIncompleteConfig = errors.New("auth: incomplete configuration")
+	// ErrUnknownGrant is returned for an unrecognised Config.GrantType value.
+	ErrUnknownGrant = errors.New("auth: unknown grant type")
+	// ErrDiscovery is returned when OIDC issuer discovery fails.
+	ErrDiscovery = errors.New("auth: OIDC discovery failed")
+)
+
+// Config describes how to build credentials. Either the static fields
+// (AccessKey/SecretKey) or the OIDC fields must be populated, not both.
+type Config struct {
+	// Static mode.
+	AccessKey string
+	SecretKey string
+
+	// OIDC mode.
+	OIDCIssuerURL    string
+	OIDCClientID     string
+	OIDCClientSecret string
+	OIDCExtraScopes  []string
+	GrantType        string
+	Username         string
+	Password         string
+}
+
+// IsStatic reports whether any static-mode field is set.
+func (c Config) IsStatic() bool {
+	return c.AccessKey != "" || c.SecretKey != ""
+}
+
+// IsOIDC reports whether any OIDC-mode field is set.
+func (c Config) IsOIDC() bool {
+	return c.OIDCIssuerURL != "" ||
+		c.OIDCClientID != "" ||
+		c.OIDCClientSecret != "" ||
+		len(c.OIDCExtraScopes) > 0 ||
+		(c.GrantType != "" && c.GrantType != GrantAuto) ||
+		c.Username != "" ||
+		c.Password != ""
+}
+
+// Option mutates BuildCredentials' internal options.
+type Option func(*options)
+
+type options struct {
+	tokenURL string
+}
+
+// WithTokenURL bypasses OIDC discovery and tells BuildCredentials to POST
+// the grant request to the given URL directly. The Config.OIDCIssuerURL is
+// still required for validation but no HTTP request is made to it. This is
+// used by integration tests and by deployments where /.well-known is
+// unreachable from the caller.
+func WithTokenURL(u string) Option {
+	return func(o *options) { o.tokenURL = u }
+}
+
+// BuildCredentials returns *credentials.Credentials suitable for both
+// minio-go and madmin-go. stsEndpoint must be a full URL with scheme
+// (e.g. "https://minio.example.com"); it is ignored in static mode.
+func BuildCredentials(ctx context.Context, stsEndpoint string, cfg Config, opts ...Option) (*credentials.Credentials, error) {
+	if cfg.IsStatic() && cfg.IsOIDC() {
+		return nil, ErrMixedModes
+	}
+	if cfg.IsStatic() {
+		if cfg.AccessKey == "" || cfg.SecretKey == "" {
+			return nil, fmt.Errorf("%w: static mode requires both access key and secret key", ErrIncompleteConfig)
+		}
+		return credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""), nil
+	}
+	if !cfg.IsOIDC() {
+		return nil, fmt.Errorf("%w (set access key/secret key or OIDC flags)", ErrNoCredentials)
+	}
+
+	grant, err := resolveGrant(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve grant type: %w", err)
+	}
+	if err := validateOIDC(cfg, grant); err != nil {
+		return nil, fmt.Errorf("validate OIDC config: %w", err)
+	}
+
+	o := options{}
+	for _, apply := range opts {
+		apply(&o)
+	}
+
+	tokenURL := o.tokenURL
+	if tokenURL == "" {
+		tokenURL, err = discoverTokenEndpoint(ctx, cfg.OIDCIssuerURL)
+		if err != nil {
+			return nil, fmt.Errorf("discover OIDC token endpoint: %w", err)
+		}
+	}
+
+	scopes := append([]string{"openid"}, cfg.OIDCExtraScopes...)
+	// The closure captures ctx from BuildCredentials. That is fine for the
+	// minio-config-cli CLI (its cmd.Context lives for the whole process), but
+	// callers that want STS-credential refresh to outlive the build call
+	// should pass a long-lived context here.
+	fetchToken := newFetchToken(ctx, cfg, grant, tokenURL, scopes)
+
+	creds, err := credentials.NewSTSWebIdentity(stsEndpoint, fetchToken)
+	if err != nil {
+		return nil, fmt.Errorf("build STS web identity credentials: %w", err)
+	}
+	return creds, nil
+}
+
+func resolveGrant(cfg Config) (string, error) {
+	switch cfg.GrantType {
+	case "", GrantAuto:
+		if cfg.Username != "" && cfg.Password != "" {
+			return GrantPassword, nil
+		}
+		return GrantClientCredentials, nil
+	case GrantPassword, GrantClientCredentials:
+		return cfg.GrantType, nil
+	default:
+		return "", fmt.Errorf("%w: %q (expected %q, %q, or %q)",
+			ErrUnknownGrant, cfg.GrantType, GrantAuto, GrantPassword, GrantClientCredentials)
+	}
+}
+
+func validateOIDC(cfg Config, grant string) error {
+	if cfg.OIDCIssuerURL == "" {
+		return fmt.Errorf("%w: OIDC mode requires --oidc-issuer-url", ErrIncompleteConfig)
+	}
+	if cfg.OIDCClientID == "" {
+		return fmt.Errorf("%w: OIDC mode requires --oidc-client-id", ErrIncompleteConfig)
+	}
+	switch grant {
+	case GrantPassword:
+		if cfg.Username == "" || cfg.Password == "" {
+			return fmt.Errorf("%w: password grant requires --username and --password", ErrIncompleteConfig)
+		}
+	case GrantClientCredentials:
+		if cfg.OIDCClientSecret == "" {
+			return fmt.Errorf("%w: client-credentials grant requires --oidc-client-secret", ErrIncompleteConfig)
+		}
+	}
+	return nil
+}
+
+func newFetchToken(ctx context.Context, cfg Config, grant, tokenURL string, scopes []string) func() (*credentials.WebIdentityToken, error) {
+	return func() (*credentials.WebIdentityToken, error) {
+		var (
+			tok *oauth2.Token
+			err error
+		)
+		switch grant {
+		case GrantClientCredentials:
+			cc := clientcredentials.Config{
+				ClientID:     cfg.OIDCClientID,
+				ClientSecret: cfg.OIDCClientSecret,
+				TokenURL:     tokenURL,
+				Scopes:       scopes,
+			}
+			tok, err = cc.Token(ctx)
+		case GrantPassword:
+			oc := oauth2.Config{
+				ClientID:     cfg.OIDCClientID,
+				ClientSecret: cfg.OIDCClientSecret,
+				Endpoint:     oauth2.Endpoint{TokenURL: tokenURL},
+				Scopes:       scopes,
+			}
+			tok, err = oc.PasswordCredentialsToken(ctx, cfg.Username, cfg.Password)
+		default:
+			return nil, fmt.Errorf("unsupported grant type %q", grant)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("fetch OIDC token: %w", err)
+		}
+		// Expiry intentionally left at zero: see PLAN §9 finding 2.
+		return &credentials.WebIdentityToken{Token: tok.AccessToken}, nil
+	}
+}
+
+func discoverTokenEndpoint(ctx context.Context, issuer string) (string, error) {
+	discURL := strings.TrimSuffix(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("%w: build request: %w", ErrDiscovery, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrDiscovery, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: status %d", ErrDiscovery, resp.StatusCode)
+	}
+	var d discoveryDocument
+	if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
+		return "", fmt.Errorf("%w: decode response: %w", ErrDiscovery, err)
+	}
+	if d.TokenEndpoint == "" {
+		return "", fmt.Errorf("%w: empty token_endpoint", ErrDiscovery)
+	}
+	return d.TokenEndpoint, nil
+}
+
+// discoveryDocument is a partial representation of the OpenID Connect
+// discovery document (RFC 8414 / OIDC Discovery 1.0). Only the fields we
+// consume are decoded.
+type discoveryDocument struct {
+	TokenEndpoint string `json:"token_endpoint"`
+}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeOIDC impersonates an OIDC discovery + token endpoint and records the
+// last token request so tests can assert what grant was used.
+type fakeOIDC struct {
+	srv          *httptest.Server
+	lastForm     url.Values
+	lastAuthUser string
+	lastAuthPass string
+}
+
+func newFakeOIDC(t *testing.T) *fakeOIDC {
+	t.Helper()
+	f := &fakeOIDC{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"token_endpoint": f.srv.URL + "/token"})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		f.lastForm = r.PostForm
+		f.lastAuthUser, f.lastAuthPass, _ = r.BasicAuth()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fake-jwt",
+			"token_type":   "Bearer",
+			"expires_in":   300,
+		})
+	})
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func TestBuildCredentials_Static(t *testing.T) {
+	t.Parallel()
+	creds, err := BuildCredentials(t.Context(), "http://minio.example.com", Config{
+		AccessKey: "ak",
+		SecretKey: "sk",
+	})
+	require.NoError(t, err)
+	// GetWithContext takes *credentials.CredContext (not context.Context);
+	// nil is documented as accepted.
+	v, err := creds.GetWithContext(nil)
+	require.NoError(t, err)
+	require.Equal(t, "ak", v.AccessKeyID)
+	require.Equal(t, "sk", v.SecretAccessKey)
+}
+
+func TestBuildCredentials_ConfigErrors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr error
+	}{
+		{"mixed modes", Config{AccessKey: "ak", SecretKey: "sk", OIDCIssuerURL: "x"}, ErrMixedModes},
+		{"no mode", Config{}, ErrNoCredentials},
+		{"static missing secret", Config{AccessKey: "ak"}, ErrIncompleteConfig},
+		{"oidc missing client id", Config{OIDCIssuerURL: "x"}, ErrIncompleteConfig},
+		{"password grant missing username", Config{OIDCIssuerURL: "x", OIDCClientID: "c", GrantType: GrantPassword}, ErrIncompleteConfig},
+		{"client-credentials missing secret", Config{OIDCIssuerURL: "x", OIDCClientID: "c", GrantType: GrantClientCredentials}, ErrIncompleteConfig},
+		{"unknown grant", Config{OIDCIssuerURL: "x", OIDCClientID: "c", GrantType: "magic"}, ErrUnknownGrant},
+		// A stray OIDC env var alone (e.g. OIDC_CLIENT_SECRET) is enough to
+		// flip into OIDC mode; it should fail with an incomplete-config error,
+		// not the "no credentials" one.
+		{"oidc client secret only", Config{OIDCClientSecret: "s"}, ErrIncompleteConfig},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := BuildCredentials(t.Context(), "http://minio.example.com", tc.cfg)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestBuildCredentials_OIDCFlows exercises the OIDC grant flows by invoking
+// the token-fetching closure through credentials.GetWithContext. The STS
+// step is expected to fail (httptest server doesn't speak STS XML); we only
+// care that the correct OAuth2 request shape was issued.
+func TestBuildCredentials_OIDCFlows(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		cfg       Config
+		wantGrant string
+		wantForm  map[string]string
+		wantBasic [2]string // user, pass (skipped if user is "")
+	}{
+		{
+			name: "client-credentials with discovery",
+			cfg: Config{
+				OIDCClientID:     "client",
+				OIDCClientSecret: "secret",
+				OIDCExtraScopes:  []string{"minio"},
+			},
+			wantGrant: "client_credentials",
+			wantForm:  map[string]string{"scope": "openid minio"},
+			wantBasic: [2]string{"client", "secret"},
+		},
+		{
+			name: "password grant",
+			cfg: Config{
+				OIDCClientID:     "client",
+				OIDCClientSecret: "secret",
+				GrantType:        GrantPassword,
+				Username:         "alice",
+				Password:         "wonderland",
+			},
+			wantGrant: "password",
+			wantForm:  map[string]string{"username": "alice", "password": "wonderland"},
+		},
+		{
+			name: "auto selects password when username given",
+			cfg: Config{
+				OIDCClientID:     "client",
+				OIDCClientSecret: "secret",
+				Username:         "alice",
+				Password:         "wonderland",
+				GrantType:        GrantAuto,
+			},
+			wantGrant: "password",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := newFakeOIDC(t)
+			cfg := tc.cfg
+			cfg.OIDCIssuerURL = f.srv.URL
+			creds, err := BuildCredentials(t.Context(), f.srv.URL, cfg)
+			require.NoError(t, err)
+			_, _ = creds.GetWithContext(nil)
+			require.Equal(t, tc.wantGrant, f.lastForm.Get("grant_type"))
+			for k, v := range tc.wantForm {
+				require.Equal(t, v, f.lastForm.Get(k), "form field %q", k)
+			}
+			if tc.wantBasic[0] != "" {
+				require.Equal(t, tc.wantBasic[0], f.lastAuthUser)
+				require.Equal(t, tc.wantBasic[1], f.lastAuthPass)
+			}
+		})
+	}
+}
+
+func TestBuildCredentials_WithTokenURLSkipsDiscovery(t *testing.T) {
+	t.Parallel()
+	f := newFakeOIDC(t)
+	// Issuer URL points at a black hole; WithTokenURL must skip discovery.
+	creds, err := BuildCredentials(t.Context(), f.srv.URL, Config{
+		OIDCIssuerURL:    "http://127.0.0.1:1",
+		OIDCClientID:     "client",
+		OIDCClientSecret: "secret",
+	}, WithTokenURL(f.srv.URL+"/token"))
+	require.NoError(t, err)
+	_, _ = creds.GetWithContext(nil)
+	require.Equal(t, "client_credentials", f.lastForm.Get("grant_type"))
+}
+
+func TestDiscoverTokenEndpoint_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(http.NotFound))
+	t.Cleanup(srv.Close)
+	_, err := discoverTokenEndpoint(t.Context(), srv.URL)
+	require.ErrorIs(t, err, ErrDiscovery)
+}

--- a/pkg/reconciliation/import_test.go
+++ b/pkg/reconciliation/import_test.go
@@ -7,14 +7,18 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/minio/madmin-go/v4"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	keycloak "github.com/stillya/testcontainers-keycloak"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	miniotestcontainer "github.com/testcontainers/testcontainers-go/modules/minio"
+	tcnetwork "github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/yardenshoham/minio-config-cli/pkg/auth"
 	"github.com/yardenshoham/minio-config-cli/pkg/validation"
 )
 
@@ -83,11 +87,52 @@ func TestImportWhenNotReady(t *testing.T) {
 
 func TestImport(t *testing.T) {
 	t.Parallel()
-	ctx, madminClient, minioClient, logger, minioContainer := testSetup(t)
-	defer func() {
-		err := testcontainers.TerminateContainer(minioContainer)
+
+	t.Run("static", func(t *testing.T) {
+		t.Parallel()
+		ctx, madminClient, minioClient, logger, minioContainer := testSetup(t)
+		defer func() {
+			err := testcontainers.TerminateContainer(minioContainer)
+			require.NoError(t, err)
+		}()
+		runImportScenario(ctx, t, madminClient, minioClient, logger)
+	})
+
+	kc := setupKeycloak(t)
+	endpoint := kc.startMinIO(t)
+
+	// The two OIDC subtests share the same MinIO: client-credentials drives the
+	// full reconciliation scenario, password only smoke-tests that STS accepts
+	// the JWT minted via the password grant. Running ServerInfo concurrently
+	// with the scenario is safe — it never mutates state.
+	t.Run("oidc/client-credentials", func(t *testing.T) {
+		t.Parallel()
+		ctx, madminClient, minioClient, logger := kc.clientsFor(t, endpoint, auth.Config{
+			OIDCIssuerURL:    kc.issuerURL,
+			OIDCClientID:     "minio-client",
+			OIDCClientSecret: "test-client-secret",
+			GrantType:        auth.GrantClientCredentials,
+		})
+		runImportScenario(ctx, t, madminClient, minioClient, logger)
+	})
+
+	t.Run("oidc/password", func(t *testing.T) {
+		t.Parallel()
+		ctx, madminClient, _, _ := kc.clientsFor(t, endpoint, auth.Config{
+			OIDCIssuerURL:    kc.issuerURL,
+			OIDCClientID:     "minio-client",
+			OIDCClientSecret: "test-client-secret",
+			GrantType:        auth.GrantPassword,
+			Username:         "testuser",
+			Password:         "testpassword",
+		})
+		_, err := madminClient.ServerInfo(ctx)
 		require.NoError(t, err)
-	}()
+	})
+}
+
+func runImportScenario(ctx context.Context, t *testing.T, madminClient *madmin.AdminClient, minioClient *minio.Client, logger *slog.Logger) {
+	t.Helper()
 	const readFoobarBucketPolicyName = "read-foobar-bucket"
 	policiesToImport := []policy{
 		{
@@ -294,4 +339,94 @@ func TestImport(t *testing.T) {
 	}
 	err = Import(ctx, logger, false, madminClient, minioClient, importConfig)
 	require.Error(t, err)
+}
+
+// keycloakEnv holds the shared Keycloak + docker-network handles used by the
+// OIDC subtests of TestImport. Each subtest spins up its own MinIO container
+// so the import-scenario assertions can run against a fresh server.
+type keycloakEnv struct {
+	nw         *testcontainers.DockerNetwork
+	kcTokenURL string // host-mapped, e.g. http://127.0.0.1:54321/realms/minio/protocol/openid-connect/token
+	issuerURL  string // what MinIO trusts: http://keycloak:8080/realms/minio
+}
+
+// setupKeycloak boots a Keycloak container with the test realm imported and
+// a shared docker network. Both are cleaned up via t.Cleanup.
+func setupKeycloak(t *testing.T) *keycloakEnv {
+	t.Helper()
+	ctx := t.Context()
+
+	nw, err := tcnetwork.New(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nw.Remove(ctx) })
+
+	kc, err := keycloak.Run(ctx, "quay.io/keycloak/keycloak:26.6.2",
+		tcnetwork.WithNetwork([]string{"keycloak"}, nw),
+		testcontainers.WithEnv(map[string]string{
+			"KC_HOSTNAME":        "http://keycloak:8080",
+			"KC_HOSTNAME_STRICT": "false",
+			"KC_HTTP_ENABLED":    "true",
+		}),
+		keycloak.WithRealmImportFile("../../testdata/minio-realm.json"),
+		keycloak.WithAdminUsername("admin"),
+		keycloak.WithAdminPassword("admin"),
+		testcontainers.WithWaitStrategy(
+			wait.ForHTTP("/realms/minio/.well-known/openid-configuration").
+				WithPort("8080/tcp").
+				WithStartupTimeout(3*time.Minute),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(kc) })
+
+	kcURL, err := kc.GetAuthServerURL(ctx)
+	require.NoError(t, err)
+
+	return &keycloakEnv{
+		nw:         nw,
+		kcTokenURL: kcURL + "/realms/minio/protocol/openid-connect/token",
+		issuerURL:  "http://keycloak:8080/realms/minio",
+	}
+}
+
+// startMinIO launches an OIDC-configured MinIO on the shared docker network
+// and returns its host-mapped endpoint. The container is registered for
+// cleanup against t.
+func (e *keycloakEnv) startMinIO(t *testing.T) string {
+	t.Helper()
+	ctx := t.Context()
+
+	mc, err := miniotestcontainer.Run(ctx, "coollabsio/minio:RELEASE.2025-10-15T17-29-55Z",
+		tcnetwork.WithNetwork(nil, e.nw),
+		testcontainers.WithEnv(map[string]string{
+			"MINIO_IDENTITY_OPENID_CONFIG_URL":    "http://keycloak:8080/realms/minio/.well-known/openid-configuration",
+			"MINIO_IDENTITY_OPENID_CLIENT_ID":     "minio-client",
+			"MINIO_IDENTITY_OPENID_CLIENT_SECRET": "test-client-secret",
+			"MINIO_IDENTITY_OPENID_SCOPES":        "openid,minio",
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = testcontainers.TerminateContainer(mc) })
+
+	endpoint, err := mc.ConnectionString(ctx)
+	require.NoError(t, err)
+	return endpoint
+}
+
+// clientsFor builds madmin/minio clients backed by STS web identity
+// credentials minted from cfg, targeting the MinIO at endpoint.
+func (e *keycloakEnv) clientsFor(t *testing.T, endpoint string, cfg auth.Config) (context.Context, *madmin.AdminClient, *minio.Client, *slog.Logger) {
+	t.Helper()
+	ctx := t.Context()
+
+	creds, err := auth.BuildCredentials(ctx, "http://"+endpoint, cfg, auth.WithTokenURL(e.kcTokenURL))
+	require.NoError(t, err)
+
+	madminClient, err := madmin.NewWithOptions(endpoint, &madmin.Options{Secure: false, Creds: creds})
+	require.NoError(t, err)
+	minioClient, err := minio.New(endpoint, &minio.Options{Secure: false, Creds: creds})
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	return ctx, madminClient, minioClient, logger
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,10 +8,19 @@
       "description": "Update MinIO test container versions in Golang tests",
       "fileMatch": ["pkg/reconciliation/import_test\\.go$"],
       "matchStrings": [
-        "miniotestcontainer\\.Run\\((?:[^,]*),\\s*\"(?<depName>coollabsio\\/minio):(?<currentValue>RELEASE\\.[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}-[\\d]{2}-[\\d]{2}Z)\", finalCustomizers\\.\\.\\.\\)"
+        "miniotestcontainer\\.Run\\((?:[^,]*),\\s*\"(?<depName>coollabsio\\/minio):(?<currentValue>RELEASE\\.[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}-[\\d]{2}-[\\d]{2}Z)\""
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Keycloak test container version in Golang tests",
+      "fileMatch": ["pkg/reconciliation/import_test\\.go$"],
+      "matchStrings": [
+        "keycloak\\.Run\\((?:[^,]*),\\s*\"(?<depName>quay\\.io/keycloak/keycloak):(?<currentValue>[\\d.]+)\""
+      ],
+      "datasourceTemplate": "docker"
     },
     {
       "customType": "regex",

--- a/testdata/minio-realm.json
+++ b/testdata/minio-realm.json
@@ -1,0 +1,84 @@
+{
+  "realm": "minio",
+  "enabled": true,
+  "accessTokenLifespan": 300,
+  "sslRequired": "none",
+  "clientScopes": [
+    {
+      "name": "minio",
+      "protocol": "openid-connect",
+      "attributes": { "include.in.token.scope": "true" },
+      "protocolMappers": [
+        {
+          "name": "minio-sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "minio-policy",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "config": {
+            "user.attribute": "minioPolicy",
+            "claim.name": "policy",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "multivalued": "false"
+          }
+        },
+        {
+          "name": "minio-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "minio-client",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "minio-client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "test-client-secret",
+      "serviceAccountsEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": false,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "fullScopeAllowed": true,
+      "defaultClientScopes": ["minio"]
+    }
+  ],
+  "users": [
+    {
+      "username": "service-account-minio-client",
+      "enabled": true,
+      "serviceAccountClientId": "minio-client",
+      "attributes": { "minioPolicy": ["consoleAdmin"] }
+    },
+    {
+      "username": "testuser",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "testuser@example.com",
+      "requiredActions": [],
+      "credentials": [
+        { "type": "password", "value": "testpassword", "temporary": false }
+      ],
+      "attributes": { "minioPolicy": ["consoleAdmin"] }
+    }
+  ]
+}

--- a/tests/chart_test.go
+++ b/tests/chart_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestMain(m *testing.M) {
@@ -37,20 +38,6 @@ func TestHelmChartTemplateRequiredValues(t *testing.T) {
 			map[string]string{
 				"accessKey": "test-access-key",
 				"secretKey": "test-secret-key",
-			},
-		},
-		{
-			"MissingAccessKey",
-			map[string]string{
-				"url":       "http://minio:9000",
-				"secretKey": "test-secret-key",
-			},
-		},
-		{
-			"MissingSecretKey",
-			map[string]string{
-				"url":       "http://minio:9000",
-				"accessKey": "test-access-key",
 			},
 		},
 	}
@@ -127,4 +114,64 @@ func TestJobNameHashChangesWithConfig(t *testing.T) {
 	// Job names should be different when extraConfig is added
 	require.NotEqual(t, job1.Name, job3.Name, "Job names should be different when extraConfig changes")
 	require.NotEqual(t, job2.Name, job3.Name, "Job names should be different when extraConfig changes")
+}
+
+func TestJobRendersAuthEnvVars(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../chart")
+	require.NoError(t, err)
+	releaseName := "minio-config-cli"
+
+	render := func(values map[string]string) batchv1.Job {
+		options := &helm.Options{SetValues: values}
+		output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/job.yaml"})
+		var job batchv1.Job
+		helm.UnmarshalK8SYaml(t, output, &job)
+		return job
+	}
+
+	envNames := func(env []corev1.EnvVar) []string {
+		out := make([]string, 0, len(env))
+		for _, e := range env {
+			out = append(out, e.Name)
+		}
+		return out
+	}
+
+	t.Run("StaticModeRendersEnvVars", func(t *testing.T) {
+		t.Parallel()
+		job := render(map[string]string{
+			"url":       "http://minio:9000",
+			"accessKey": "ak",
+			"secretKey": "sk",
+		})
+		require.Len(t, job.Spec.Template.Spec.Containers, 1)
+		env := job.Spec.Template.Spec.Containers[0].Env
+		names := envNames(env)
+		require.Contains(t, names, "MINIO_ACCESS_KEY")
+		require.Contains(t, names, "MINIO_SECRET_KEY")
+		require.NotContains(t, names, "OIDC_ISSUER_URL")
+		require.NotContains(t, names, "OIDC_CLIENT_ID")
+		// Positional args: only the URL.
+		require.Equal(t, []string{"import", "http://minio:9000", "--import-file-location=/configs"},
+			job.Spec.Template.Spec.Containers[0].Args)
+	})
+
+	t.Run("OIDCModeRendersEnvVars", func(t *testing.T) {
+		t.Parallel()
+		job := render(map[string]string{
+			"url":              "https://minio.example.com",
+			"oidcIssuerUrl":    "https://keycloak.example.com/realms/minio",
+			"oidcClientId":     "minio-client",
+			"oidcClientSecret": "secret",
+		})
+		env := job.Spec.Template.Spec.Containers[0].Env
+		names := envNames(env)
+		require.Contains(t, names, "OIDC_ISSUER_URL")
+		require.Contains(t, names, "OIDC_CLIENT_ID")
+		require.Contains(t, names, "OIDC_CLIENT_SECRET")
+		require.NotContains(t, names, "MINIO_ACCESS_KEY")
+		require.NotContains(t, names, "MINIO_SECRET_KEY")
+	})
 }


### PR DESCRIPTION
The import command now accepts MinIO STS credentials via OIDC (AssumeRoleWithWebIdentity) in addition to the existing static access-key/secret-key flow. Both the client-credentials and resource-owner password grants are supported, auto-detected from the supplied flags or forced via --grant-type, and all flags fall back to environment variables so the Helm chart and other operators can pass secrets through env without inlining them in arguments.

The MINIO_URL is now the only positional argument; access key and secret key move to --access-key/--secret-key flags. The Helm chart renders the credentials as env vars (MINIO_ACCESS_KEY, MINIO_SECRET_KEY, OIDC_*) instead of args so secret values don't leak into the pod spec, and accessKey/secretKey are no longer required when OIDC values are provided.

Credential building lives in the new pkg/auth package with unit tests covering static, mixed-mode, discovery, both grants, and the WithTokenURL escape hatch used by the integration tests. The reconciliation integration test now also spins up a Keycloak testcontainer (with a minio realm in testdata/) and runs the full import scenario against an OIDC-secured MinIO via both grants.