### PR TITLE
Add variable substitution to config import

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,57 @@ As a URL:
 https://raw.githubusercontent.com/yardenshoham/minio-config-cli/refs/heads/main/pkg/validation/schema.json
 ```
 
+# Variable Substitution
+
+Config files support variable substitution using the syntax `$(prefix:key)`.
+Substitution is always enabled and is applied to the raw config text before
+validation and unmarshaling.
+
+## Syntax
+
+```
+$(prefix:key)
+```
+
+Expressions are resolved inside-out, so nesting is supported:
+
+```
+$(file:$(env:CONFIG_PATH))
+```
+
+To include a literal `$(prefix:key)` string without substitution, escape it with
+a double `$`:
+
+```
+$$(env:HOME)  →  $(env:HOME)
+```
+
+## Supported Prefixes
+
+| Prefix          | Description                                    | Example                                                  |
+| --------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `env`           | Value of an environment variable               | `$(env:HOME)` → `/home/user`                             |
+| `file`          | Contents of a file (relative to working dir)   | `$(file:secrets/key.txt)` → file contents                |
+| `base64Decoder` | Decode a Base64 string                         | `$(base64Decoder:SGVsbG8=)` → `Hello`                    |
+| `base64Encoder` | Encode a string to Base64                      | `$(base64Encoder:Hello)` → `SGVsbG8=`                    |
+| `urlDecoder`    | URL-decode a string                            | `$(urlDecoder:Hello%20World)` → `Hello World`            |
+| `urlEncoder`    | URL-encode a string                            | `$(urlEncoder:Hello World)` → `Hello+World`              |
+| `url`           | Fetch content from an HTTP, HTTPS, or file URL | `$(url:https://example.com/policy.json)` → response body |
+
+## Example
+
+```yaml
+buckets:
+  - name: $(env:BUCKET_NAME)
+users:
+  - accessKey: $(env:MINIO_ACCESS_KEY)
+    secretKey: $(file:secrets/minio-secret-key.txt)
+    status: enabled
+policies:
+  - name: my-policy
+    policy: $(url:https://example.com/policy.json)
+```
+
 # Build this project
 
 ```bash

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -94,7 +94,7 @@ minio-config-cli import https://minio.example.com \
 				if err != nil {
 					return fmt.Errorf("failed to open file %s: %w", path, err)
 				}
-				config, err := reconciliation.LoadConfig(file)
+				config, err := reconciliation.LoadConfig(ctx, file)
 				file.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load config from file %s: %w", path, err)

--- a/pkg/reconciliation/import.go
+++ b/pkg/reconciliation/import.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/minio/madmin-go/v4"
 	"github.com/minio/minio-go/v7"
+	"github.com/yardenshoham/minio-config-cli/pkg/substitution"
 	"github.com/yardenshoham/minio-config-cli/pkg/validation"
 )
 
@@ -21,18 +22,22 @@ type ImportConfig struct {
 }
 
 // LoadConfig loads the config file into a struct.
-func LoadConfig(r io.Reader) (*ImportConfig, error) {
+func LoadConfig(ctx context.Context, r io.Reader) (*ImportConfig, error) {
 	var readerText bytes.Buffer
 	_, err := io.Copy(&readerText, r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config: %w", err)
 	}
-	err = validation.ValidateConfig(bytes.NewReader(readerText.Bytes()))
+	substituted, err := substitution.Substitute(ctx, readerText.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to substitute variables in config: %w", err)
+	}
+	err = validation.ValidateConfig(bytes.NewReader(substituted))
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate config: %w", err)
 	}
 	config := &ImportConfig{}
-	err = yaml.Unmarshal(readerText.Bytes(), config)
+	err = yaml.Unmarshal(substituted, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode config: %w", err)
 	}

--- a/pkg/reconciliation/import_test.go
+++ b/pkg/reconciliation/import_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -290,7 +291,7 @@ func runImportScenario(ctx context.Context, t *testing.T, madminClient *madmin.A
 	require.NoError(t, err)
 	defer testdataConfigFile.Close()
 
-	testdataConfig, err := LoadConfig(testdataConfigFile)
+	testdataConfig, err := LoadConfig(ctx, testdataConfigFile)
 	require.NoError(t, err)
 	err = Import(ctx, logger, false, madminClient, minioClient, *testdataConfig)
 	require.NoError(t, err)
@@ -429,4 +430,13 @@ func (e *keycloakEnv) clientsFor(t *testing.T, endpoint string, cfg auth.Config)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	return ctx, madminClient, minioClient, logger
+}
+
+func TestLoadConfigVariableSubstitution(t *testing.T) {
+	t.Setenv("_TEST_LOADCONFIG_BUCKET", "substituted-bucket")
+
+	cfg, err := LoadConfig(t.Context(), strings.NewReader("buckets:\n  - name: $(env:_TEST_LOADCONFIG_BUCKET)\n"))
+	require.NoError(t, err)
+	require.Len(t, cfg.Buckets, 1)
+	require.Equal(t, "substituted-bucket", cfg.Buckets[0].Name)
 }

--- a/pkg/substitution/base64.go
+++ b/pkg/substitution/base64.go
@@ -1,0 +1,23 @@
+package substitution
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+)
+
+type base64DecoderLookup struct{}
+
+func (l *base64DecoderLookup) Lookup(_ context.Context, key []byte) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(string(key))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64 value %q: %w", key, err)
+	}
+	return decoded, nil
+}
+
+type base64EncoderLookup struct{}
+
+func (l *base64EncoderLookup) Lookup(_ context.Context, key []byte) ([]byte, error) {
+	return base64.StdEncoding.AppendEncode(nil, key), nil
+}

--- a/pkg/substitution/env.go
+++ b/pkg/substitution/env.go
@@ -1,0 +1,17 @@
+package substitution
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+type envLookup struct{}
+
+func (l *envLookup) Lookup(_ context.Context, key []byte) ([]byte, error) {
+	value, exists := os.LookupEnv(string(key))
+	if !exists {
+		return nil, fmt.Errorf("failed to resolve env var %q: not defined", key)
+	}
+	return []byte(value), nil
+}

--- a/pkg/substitution/file.go
+++ b/pkg/substitution/file.go
@@ -1,0 +1,20 @@
+package substitution
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+type fileLookup struct{}
+
+// Lookup reads the file at path and returns its content.
+// Path resolution follows os.ReadFile semantics: relative paths are resolved
+// against the process's current working directory.
+func (l *fileLookup) Lookup(_ context.Context, path []byte) ([]byte, error) {
+	content, err := os.ReadFile(string(path))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+	return content, nil
+}

--- a/pkg/substitution/lookup.go
+++ b/pkg/substitution/lookup.go
@@ -1,0 +1,8 @@
+package substitution
+
+import "context"
+
+// Lookup resolves a variable value for a given key.
+type Lookup interface {
+	Lookup(ctx context.Context, key []byte) ([]byte, error)
+}

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -1,0 +1,111 @@
+package substitution
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"slices"
+)
+
+// innermostPattern matches $(prefix:key) where the value contains no $, (, or ).
+// This identifies the innermost (deepest) variable reference, enabling inside-out resolution.
+var innermostPattern = regexp.MustCompile(`\$\(([^$()]+)\)`)
+
+// escapePrefix and escapePlaceholder are used to protect $$( sequences during substitution.
+var (
+	escapePrefix      = []byte("$$(")
+	escapePlaceholder = []byte("\x00ESCAPED_VAR_PREFIX\x00")
+	varPrefix         = []byte("$(")
+)
+
+// ErrUnknownPrefix is returned by Substitute when a variable references a prefix that is not registered.
+var ErrUnknownPrefix = errors.New("unknown variable prefix")
+
+// Option configures the Substitute function.
+type Option func(*substituter)
+
+// WithHTTPClient injects a custom HTTP client used by the url lookup.
+// Useful for testing with httptest.NewServer.
+func WithHTTPClient(client *http.Client) Option {
+	return func(s *substituter) {
+		s.httpClient = client
+	}
+}
+
+type substituter struct {
+	httpClient *http.Client
+}
+
+// Substitute replaces all $(prefix:key) occurrences in input with their resolved values.
+// Substitution proceeds inside-out: the innermost variable is resolved first, which
+// allows nested expressions such as $(file:$(env:CONFIG_PATH)).
+//
+// To include a literal $(prefix:key) in the output without substitution, escape it
+// as $$(prefix:key). All other text is passed through unchanged.
+func Substitute(ctx context.Context, input []byte, opts ...Option) ([]byte, error) {
+	s := &substituter{
+		httpClient: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s.substitute(ctx, input)
+}
+
+func (s *substituter) substitute(ctx context.Context, input []byte) ([]byte, error) {
+	const maxIterations = 50
+	registry := s.buildRegistry()
+
+	// Replace $$( escape sequences with a placeholder to protect them from substitution.
+	working := bytes.ReplaceAll(input, escapePrefix, escapePlaceholder)
+
+	for range maxIterations {
+		match := innermostPattern.FindSubmatchIndex(working)
+		if match == nil {
+			break
+		}
+		inner := working[match[2]:match[3]]
+		resolved, err := s.resolve(ctx, inner, registry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to substitute variable %q: %w", string(inner), err)
+		}
+		working = slices.Concat(working[:match[0]], resolved, working[match[1]:])
+	}
+
+	// If patterns remain after reaching the iteration limit, report an error.
+	if innermostPattern.Match(working) {
+		return nil, fmt.Errorf("failed to substitute variables: maximum iteration limit reached, possible circular reference")
+	}
+
+	// Restore escaped sequences to their literal form.
+	return bytes.ReplaceAll(working, escapePlaceholder, varPrefix), nil
+}
+
+func (s *substituter) buildRegistry() map[string]Lookup {
+	return map[string]Lookup{
+		"base64Decoder": &base64DecoderLookup{},
+		"base64Encoder": &base64EncoderLookup{},
+		"env":           &envLookup{},
+		"file":          &fileLookup{},
+		"urlDecoder":    &urlDecoderLookup{},
+		"urlEncoder":    &urlEncoderLookup{},
+		"url":           &urlContentLookup{httpClient: s.httpClient},
+	}
+}
+
+func (s *substituter) resolve(ctx context.Context, inner []byte, registry map[string]Lookup) ([]byte, error) {
+	before, after, ok := bytes.Cut(inner, []byte{':'})
+	if !ok {
+		return nil, fmt.Errorf("missing prefix separator ':' in variable %q", string(inner))
+	}
+	prefix := string(before)
+
+	lookup, ok := registry[prefix]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownPrefix, prefix)
+	}
+	return lookup.Lookup(ctx, after)
+}

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -1,0 +1,146 @@
+package substitution
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstitute(t *testing.T) {
+	// Stateless transformations: input → expected output, no external dependencies.
+	t.Run("transforms", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct{ name, input, want string }{
+			{"no patterns", "no variables here", "no variables here"},
+			{"empty", "", ""},
+			{"base64Decoder", "$(base64Decoder:SGVsbG8=)", "Hello"},
+			{"base64Encoder", "$(base64Encoder:Hello)", "SGVsbG8="},
+			{"urlDecoder", "$(urlDecoder:Hello%20World)", "Hello World"},
+			{"urlEncoder", "$(urlEncoder:Hello World)", "Hello+World"},
+			{"escape", "$$(env:HOME)", "$(env:HOME)"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				result, err := Substitute(t.Context(), []byte(tc.input))
+				require.NoError(t, err)
+				require.Equal(t, tc.want, string(result))
+			})
+		}
+	})
+
+	// Error cases that require no external setup.
+	t.Run("errors", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name        string
+			input       string
+			errContains string
+			errIs       error
+		}{
+			{"env/undefined", "$(env:_SUBST_SURELY_NOT_SET_XYZ_12345)", "_SUBST_SURELY_NOT_SET_XYZ_12345", nil},
+			{"base64Decoder/invalid", "$(base64Decoder:!!!notbase64!!!)", "failed to decode base64", nil},
+			{"file/not found", "$(file:/nonexistent/path/file.txt)", "", os.ErrNotExist},
+			{"url/unsupported scheme", "$(url:ftp://example.com)", "", ErrUnsupportedURLScheme},
+			{"unknown prefix", "$(unknown:value)", "", ErrUnknownPrefix},
+			{"missing colon", "$(noseparator)", "missing prefix separator", nil},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				_, err := Substitute(t.Context(), []byte(tc.input))
+				if tc.errIs != nil {
+					require.ErrorIs(t, err, tc.errIs)
+				} else {
+					require.ErrorContains(t, err, tc.errContains)
+				}
+			})
+		}
+	})
+
+	t.Run("env/found", func(t *testing.T) {
+		t.Setenv("_TEST_SUBST_VAR", "hello")
+		result, err := Substitute(t.Context(), []byte("$(env:_TEST_SUBST_VAR)"))
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(result))
+	})
+
+	t.Run("multiple substitutions", func(t *testing.T) {
+		t.Setenv("_TEST_BUCKET_A", "foo")
+		t.Setenv("_TEST_BUCKET_B", "bar")
+		result, err := Substitute(t.Context(), []byte("$(env:_TEST_BUCKET_A)-$(env:_TEST_BUCKET_B)"))
+		require.NoError(t, err)
+		require.Equal(t, "foo-bar", string(result))
+	})
+
+	t.Run("escape alongside substitution", func(t *testing.T) {
+		t.Setenv("_TEST_ESCAPE_VAR", "resolved")
+		result, err := Substitute(t.Context(), []byte("$(env:_TEST_ESCAPE_VAR) and $$(env:_TEST_ESCAPE_VAR)"))
+		require.NoError(t, err)
+		require.Equal(t, "resolved and $(env:_TEST_ESCAPE_VAR)", string(result))
+	})
+
+	t.Run("file/found", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "test.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("file content"), 0600))
+		result, err := Substitute(t.Context(), fmt.Appendf(nil, "$(file:%s)", filePath))
+		require.NoError(t, err)
+		require.Equal(t, "file content", string(result))
+	})
+
+	t.Run("url/http 200", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "server response")
+		}))
+		defer server.Close()
+		result, err := Substitute(t.Context(), fmt.Appendf(nil, "$(url:%s)", server.URL), WithHTTPClient(server.Client()))
+		require.NoError(t, err)
+		require.Equal(t, "server response", string(result))
+	})
+
+	t.Run("url/http non-200", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+		_, err := Substitute(t.Context(), fmt.Appendf(nil, "$(url:%s)", server.URL), WithHTTPClient(server.Client()))
+		require.ErrorContains(t, err, "HTTP status 404")
+	})
+
+	t.Run("url/file scheme", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "remote.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("from file url"), 0600))
+		// filePath is absolute (starts with /), so file:// + filePath gives file:///path/...
+		result, err := Substitute(t.Context(), fmt.Appendf(nil, "$(url:file://%s)", filePath))
+		require.NoError(t, err)
+		require.Equal(t, "from file url", string(result))
+	})
+
+	t.Run("nested substitution", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "name.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("world"), 0600))
+		t.Setenv("_TEST_NESTED_FILE_PATH", filePath)
+		result, err := Substitute(t.Context(), []byte("$(file:$(env:_TEST_NESTED_FILE_PATH))"))
+		require.NoError(t, err)
+		require.Equal(t, "world", string(result))
+	})
+
+	t.Run("yaml-like config", func(t *testing.T) {
+		t.Setenv("_TEST_YAML_BUCKET", "my-bucket")
+		result, err := Substitute(t.Context(), []byte("buckets:\n  - name: $(env:_TEST_YAML_BUCKET)\n"))
+		require.NoError(t, err)
+		require.Equal(t, "buckets:\n  - name: my-bucket\n", string(result))
+	})
+}

--- a/pkg/substitution/url_content.go
+++ b/pkg/substitution/url_content.go
@@ -1,0 +1,54 @@
+package substitution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ErrUnsupportedURLScheme is returned by the url lookup when the URL uses a scheme other than http, https, or file.
+var ErrUnsupportedURLScheme = errors.New("unsupported URL scheme")
+
+type urlContentLookup struct {
+	httpClient *http.Client
+}
+
+func (l *urlContentLookup) Lookup(ctx context.Context, rawURL []byte) ([]byte, error) {
+	parsed, err := url.Parse(string(rawURL))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL %q: %w", rawURL, err)
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return l.fetchHTTP(ctx, string(rawURL))
+	case "file":
+		return new(fileLookup).Lookup(ctx, []byte(parsed.Path))
+	default:
+		return nil, fmt.Errorf("failed to fetch URL %q with unsupported scheme %q: %w", rawURL, parsed.Scheme, ErrUnsupportedURLScheme)
+	}
+}
+
+func (l *urlContentLookup) fetchHTTP(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for URL %q: %w", rawURL, err)
+	}
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch URL %q: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch URL %q: HTTP status %d", rawURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response from URL %q: %w", rawURL, err)
+	}
+	return body, nil
+}

--- a/pkg/substitution/url_encoding.go
+++ b/pkg/substitution/url_encoding.go
@@ -1,0 +1,23 @@
+package substitution
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+type urlDecoderLookup struct{}
+
+func (l *urlDecoderLookup) Lookup(_ context.Context, key []byte) ([]byte, error) {
+	decoded, err := url.QueryUnescape(string(key))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode URL-encoded string %q: %w", key, err)
+	}
+	return []byte(decoded), nil
+}
+
+type urlEncoderLookup struct{}
+
+func (l *urlEncoderLookup) Lookup(_ context.Context, key []byte) ([]byte, error) {
+	return []byte(url.QueryEscape(string(key))), nil
+}


### PR DESCRIPTION
This introduces flexible configuration management by resolving substitution expressions before schema validation and unmarshaling, so config values can be sourced from environment variables, files, encoders/decoders, and URLs.