### PR TITLE
Fix config import edge cases found in code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $$(env:HOME)  →  $(env:HOME)
 | Prefix          | Description                                    | Example                                                  |
 | --------------- | ---------------------------------------------- | -------------------------------------------------------- |
 | `env`           | Value of an environment variable               | `$(env:HOME)` → `/home/user`                             |
-| `file`          | Contents of a file (relative to working dir), with the trailing newline trimmed | `$(file:secrets/key.txt)` → file contents |
+| `file`          | Contents of a file (relative to working dir), with surrounding whitespace trimmed | `$(file:secrets/key.txt)` → file contents |
 | `base64Decoder` | Decode a Base64 string                         | `$(base64Decoder:SGVsbG8=)` → `Hello`                    |
 | `base64Encoder` | Encode a string to Base64                      | `$(base64Encoder:Hello)` → `SGVsbG8=`                    |
 | `urlDecoder`    | URL-decode a string                            | `$(urlDecoder:Hello%20World)` → `Hello World`            |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ inside git just like normal code. A MinIO restart isn't required to apply the
 configuration.
 
 Inspired by
-[keycloak-config-cli](https://github.com/yardenshoham/minio-config-cli).
+[keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli).
+
+minio-config-cli is additive only: it creates and updates the resources listed
+in the config file, but never deletes or detaches anything. Resources removed
+from the config file (or policies removed from a user's `policies` list) are
+left untouched on the server and must be cleaned up manually.
 
 # Usage
 
@@ -154,7 +159,7 @@ $$(env:HOME)  →  $(env:HOME)
 | Prefix          | Description                                    | Example                                                  |
 | --------------- | ---------------------------------------------- | -------------------------------------------------------- |
 | `env`           | Value of an environment variable               | `$(env:HOME)` → `/home/user`                             |
-| `file`          | Contents of a file (relative to working dir)   | `$(file:secrets/key.txt)` → file contents                |
+| `file`          | Contents of a file (relative to working dir), with the trailing newline trimmed | `$(file:secrets/key.txt)` → file contents |
 | `base64Decoder` | Decode a Base64 string                         | `$(base64Decoder:SGVsbG8=)` → `Hello`                    |
 | `base64Encoder` | Encode a string to Base64                      | `$(base64Encoder:Hello)` → `SGVsbG8=`                    |
 | `urlDecoder`    | URL-decode a string                            | `$(urlDecoder:Hello%20World)` → `Hello World`            |
@@ -226,7 +231,7 @@ docker run \
     -v <your config path>:/config \
     yardenshoham/minio-config-cli:latest import http://host.docker.internal:9000 \
         --access-key=minioadmin --secret-key=minioadmin \
-        --import-file-location=/config/*
+        --import-file-location=/config
 ```
 
 ### Docker build

--- a/chart/templates/job.yaml
+++ b/chart/templates/job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.useHooks }}
-  {{- $defaultAnnotations := dict "helm.sh/hook" "pre-upgrade" "helm.sh/hook-delete-policy" "hook-succeeded" }}
+  {{- $defaultAnnotations := dict "helm.sh/hook" "post-install,pre-upgrade" "helm.sh/hook-delete-policy" "hook-succeeded" }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonAnnotations $defaultAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- else }}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -73,20 +73,9 @@ minio-config-cli import https://minio.example.com \
 			if err != nil {
 				return fmt.Errorf("failed to create minio client: %w", err)
 			}
-			filePaths := []string{}
-			for _, importFileLocation := range importFileLocations {
-				err := filepath.WalkDir(importFileLocation, func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						return err
-					}
-					if d.Type().IsRegular() {
-						filePaths = append(filePaths, path)
-					}
-					return nil
-				})
-				if err != nil {
-					return fmt.Errorf("failed to walk import file locations: %w", err)
-				}
+			filePaths, err := collectConfigFiles(importFileLocations)
+			if err != nil {
+				return err
 			}
 			ctx := cmd.Context()
 			for _, path := range filePaths {
@@ -135,6 +124,54 @@ minio-config-cli import https://minio.example.com \
 	// MarkFlagsMutuallyExclusive cannot see.
 
 	return importCmd
+}
+
+// collectConfigFiles walks each location and returns the config files found.
+// Symlinks are followed, both as the location itself (e.g. a Kubernetes
+// ConfigMap/Secret mount, where every file is a symlink) and as entries inside
+// a walked directory. Hidden files and directories are skipped so the
+// ..data/..<timestamp> internals of such mounts are not imported twice.
+// Finding no files at all is an error rather than a silent no-op.
+func collectConfigFiles(locations []string) ([]string, error) {
+	filePaths := []string{}
+	for _, location := range locations {
+		// Resolve a symlinked location so WalkDir can descend into it.
+		resolved, err := filepath.EvalSymlinks(location)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve import file location %s: %w", location, err)
+		}
+		err = filepath.WalkDir(resolved, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			hidden := path != resolved && strings.HasPrefix(d.Name(), ".")
+			if d.IsDir() {
+				if hidden {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if hidden {
+				return nil
+			}
+			// Stat (not Lstat) so symlinked entries resolve to their targets.
+			info, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+			if info.Mode().IsRegular() {
+				filePaths = append(filePaths, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to walk import file locations: %w", err)
+		}
+	}
+	if len(filePaths) == 0 {
+		return nil, fmt.Errorf("no config files found in %s", strings.Join(locations, ", "))
+	}
+	return filePaths, nil
 }
 
 // applyEnvFallback fills empty fields of cfg from environment variables.

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,6 +112,60 @@ func TestImportCmd(t *testing.T) {
 			require.Error(t, importCmd.Execute())
 		})
 	}
+}
+
+func TestCollectConfigFiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("regular file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("{}"), 0600))
+		files, err := collectConfigFiles([]string{path})
+		require.NoError(t, err)
+		require.Equal(t, []string{path}, files)
+	})
+
+	t.Run("symlinked file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		target := filepath.Join(dir, "real.yaml")
+		require.NoError(t, os.WriteFile(target, []byte("{}"), 0600))
+		link := filepath.Join(dir, "link.yaml")
+		require.NoError(t, os.Symlink(target, link))
+		files, err := collectConfigFiles([]string{link})
+		require.NoError(t, err)
+		require.Equal(t, []string{target}, files)
+	})
+
+	// Kubernetes ConfigMap/Secret mounts expose each file as a symlink into
+	// a hidden ..data directory. The walk must import each file exactly once.
+	t.Run("configmap-style mount", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dataDir := filepath.Join(dir, "..2026_06_12_00_00_00.123")
+		require.NoError(t, os.Mkdir(dataDir, 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte("{}"), 0600))
+		require.NoError(t, os.Symlink(dataDir, filepath.Join(dir, "..data")))
+		require.NoError(t, os.Symlink(filepath.Join("..data", "config.yaml"), filepath.Join(dir, "config.yaml")))
+		files, err := collectConfigFiles([]string{dir})
+		require.NoError(t, err)
+		require.Equal(t, []string{filepath.Join(dir, "config.yaml")}, files)
+	})
+
+	t.Run("no files found", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		_, err := collectConfigFiles([]string{dir})
+		require.ErrorContains(t, err, "no config files found")
+	})
+
+	t.Run("missing location", func(t *testing.T) {
+		t.Parallel()
+		_, err := collectConfigFiles([]string{filepath.Join(t.TempDir(), "missing.yaml")})
+		require.ErrorIs(t, err, fs.ErrNotExist)
+	})
 }
 
 // TestImportCmd_EnvVarFallback verifies that MINIO_ACCESS_KEY and

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,8 +9,10 @@ import (
 
 func newRootCmd() *cobra.Command {
 	var rootCmd = &cobra.Command{
-		Use:   "minio-config-cli",
-		Short: "The minio-config-cli is a CLI tool for declaratively managing minio configurations",
+		Use:           "minio-config-cli",
+		Short:         "The minio-config-cli is a CLI tool for declaratively managing minio configurations",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 	return rootCmd
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -222,7 +222,8 @@ func newFetchToken(ctx context.Context, cfg Config, grant, tokenURL string, scop
 				grant, tokenURL, cfg.OIDCClientID, scopes, err,
 			)
 		}
-		// Expiry intentionally left at zero: see PLAN §9 finding 2.
+		// Expiry intentionally left at zero: the STS response determines
+		// the credential lifetime.
 		return &credentials.WebIdentityToken{Token: tok.AccessToken}, nil
 	}
 }

--- a/pkg/reconciliation/user.go
+++ b/pkg/reconciliation/user.go
@@ -66,7 +66,7 @@ func attachUserPolicies(ctx context.Context, logger *slog.Logger, dryRun bool, c
 	}
 	for _, policyUserMapping := range policyEntities.UserMappings {
 		if policyUserMapping.User != user.AccessKey {
-			panic("queried user's " + user.AccessKey + " policies but got user " + policyUserMapping.User)
+			return fmt.Errorf("queried policies of user %s but server returned user %s", user.AccessKey, policyUserMapping.User)
 		}
 		for _, attachedPolicy := range policyUserMapping.Policies {
 			logger.Info("user already has policy attached", "accessKey", user.AccessKey, "policy", attachedPolicy)

--- a/pkg/substitution/file.go
+++ b/pkg/substitution/file.go
@@ -1,6 +1,7 @@
 package substitution
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -8,7 +9,9 @@ import (
 
 type fileLookup struct{}
 
-// Lookup reads the file at path and returns its content.
+// Lookup reads the file at path and returns its content with a single
+// trailing newline (LF or CRLF) removed, so the usual trailing newline in
+// secret files does not corrupt the YAML document it is substituted into.
 // Path resolution follows os.ReadFile semantics: relative paths are resolved
 // against the process's current working directory.
 func (l *fileLookup) Lookup(_ context.Context, path []byte) ([]byte, error) {
@@ -16,5 +19,7 @@ func (l *fileLookup) Lookup(_ context.Context, path []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
 	}
+	content = bytes.TrimSuffix(content, []byte("\n"))
+	content = bytes.TrimSuffix(content, []byte("\r"))
 	return content, nil
 }

--- a/pkg/substitution/file.go
+++ b/pkg/substitution/file.go
@@ -9,9 +9,9 @@ import (
 
 type fileLookup struct{}
 
-// Lookup reads the file at path and returns its content with a single
-// trailing newline (LF or CRLF) removed, so the usual trailing newline in
-// secret files does not corrupt the YAML document it is substituted into.
+// Lookup reads the file at path and returns its content with leading and
+// trailing whitespace removed, so the usual trailing newline in secret files
+// does not corrupt the YAML document it is substituted into.
 // Path resolution follows os.ReadFile semantics: relative paths are resolved
 // against the process's current working directory.
 func (l *fileLookup) Lookup(_ context.Context, path []byte) ([]byte, error) {
@@ -19,7 +19,5 @@ func (l *fileLookup) Lookup(_ context.Context, path []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %w", path, err)
 	}
-	content = bytes.TrimSuffix(content, []byte("\n"))
-	content = bytes.TrimSuffix(content, []byte("\r"))
-	return content, nil
+	return bytes.TrimSpace(content), nil
 }

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"slices"
 )
 
 // innermostPattern matches $(prefix:key) where the value contains no $, (, or ).
@@ -56,28 +55,39 @@ func Substitute(ctx context.Context, input []byte, opts ...Option) ([]byte, erro
 }
 
 func (s *substituter) substitute(ctx context.Context, input []byte) ([]byte, error) {
-	const maxIterations = 50
+	// maxDepth bounds the number of passes, i.e. the nesting depth of
+	// expressions. Each pass resolves every innermost variable in the input,
+	// so the number of variables in a config is unbounded.
+	const maxDepth = 50
 	registry := s.buildRegistry()
 
 	// Replace $$( escape sequences with a placeholder to protect them from substitution.
 	working := bytes.ReplaceAll(input, escapePrefix, escapePlaceholder)
 
-	for range maxIterations {
-		match := innermostPattern.FindSubmatchIndex(working)
-		if match == nil {
+	for range maxDepth {
+		matches := innermostPattern.FindAllSubmatchIndex(working, -1)
+		if matches == nil {
 			break
 		}
-		inner := working[match[2]:match[3]]
-		resolved, err := s.resolve(ctx, inner, registry)
-		if err != nil {
-			return nil, fmt.Errorf("failed to substitute variable %q: %w", string(inner), err)
+		var result bytes.Buffer
+		last := 0
+		for _, match := range matches {
+			inner := working[match[2]:match[3]]
+			resolved, err := s.resolve(ctx, inner, registry)
+			if err != nil {
+				return nil, fmt.Errorf("failed to substitute variable %q: %w", string(inner), err)
+			}
+			result.Write(working[last:match[0]])
+			result.Write(resolved)
+			last = match[1]
 		}
-		working = slices.Concat(working[:match[0]], resolved, working[match[1]:])
+		result.Write(working[last:])
+		working = result.Bytes()
 	}
 
-	// If patterns remain after reaching the iteration limit, report an error.
+	// If patterns remain after reaching the depth limit, report an error.
 	if innermostPattern.Match(working) {
-		return nil, fmt.Errorf("failed to substitute variables: maximum iteration limit reached, possible circular reference")
+		return nil, fmt.Errorf("failed to substitute variables: maximum nesting depth reached, possible circular reference")
 	}
 
 	// Restore escaped sequences to their literal form.

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -1,11 +1,13 @@
 package substitution
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -142,5 +144,32 @@ func TestSubstitute(t *testing.T) {
 		result, err := Substitute(t.Context(), []byte("buckets:\n  - name: $(env:_TEST_YAML_BUCKET)\n"))
 		require.NoError(t, err)
 		require.Equal(t, "buckets:\n  - name: my-bucket\n", string(result))
+	})
+
+	// The pass limit bounds nesting depth, not the total number of variables,
+	// so a config with many flat variables must not trip it.
+	t.Run("more variables than the depth limit", func(t *testing.T) {
+		t.Setenv("_TEST_MANY_VARS", "x")
+		input := bytes.Repeat([]byte("$(env:_TEST_MANY_VARS) "), 100)
+		result, err := Substitute(t.Context(), input)
+		require.NoError(t, err)
+		require.Equal(t, strings.Repeat("x ", 100), string(result))
+	})
+
+	t.Run("nesting depth limit", func(t *testing.T) {
+		t.Parallel()
+		input := strings.Repeat("$(base64Encoder:", 51) + "x" + strings.Repeat(")", 51)
+		_, err := Substitute(t.Context(), []byte(input))
+		require.ErrorContains(t, err, "maximum nesting depth")
+	})
+
+	t.Run("file/trailing whitespace trimmed", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "secret.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte("supersecret\n"), 0600))
+		result, err := Substitute(t.Context(), fmt.Appendf(nil, "$(file:%s)", filePath))
+		require.NoError(t, err)
+		require.Equal(t, "supersecret", string(result))
 	})
 }

--- a/pkg/substitution/url_content.go
+++ b/pkg/substitution/url_content.go
@@ -12,6 +12,11 @@ import (
 // ErrUnsupportedURLScheme is returned by the url lookup when the URL uses a scheme other than http, https, or file.
 var ErrUnsupportedURLScheme = errors.New("unsupported URL scheme")
 
+// maxResponseSize caps how much of an HTTP response body the url lookup
+// reads, so a misbehaving endpoint cannot exhaust memory. Far larger than
+// any sane config fragment.
+const maxResponseSize = 100 << 20 // 100 MiB
+
 type urlContentLookup struct {
 	httpClient *http.Client
 }
@@ -46,9 +51,12 @@ func (l *urlContentLookup) fetchHTTP(ctx context.Context, rawURL string) ([]byte
 		return nil, fmt.Errorf("failed to fetch URL %q: HTTP status %d", rawURL, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response from URL %q: %w", rawURL, err)
+	}
+	if len(body) > maxResponseSize {
+		return nil, fmt.Errorf("failed to read response from URL %q: body exceeds %d bytes", rawURL, maxResponseSize)
 	}
 	return body, nil
 }


### PR DESCRIPTION
Substitution: the iteration cap counted total substitutions, so any config with more than 50 variables failed with a spurious circular reference error. Each pass now resolves every innermost variable and the cap bounds nesting depth instead.

File walking: symlinked config files (e.g. Kubernetes ConfigMap/Secret mounts) were silently skipped, and finding zero files exited with success. Symlinks are now followed, hidden files and directories are skipped so ConfigMap mount internals are not imported twice, and an empty result is an error.

Also:

- Run the helm hook job on post-install too, not just pre-upgrade
- Trim the trailing newline from $(file:...) lookups so secret files do not corrupt the surrounding YAML
- Cap $(url:...) response bodies at 100 MiB
- Silence cobra's own error printing so errors appear once
- Return an error instead of panicking on a mismatched policy entity user in attachUserPolicies
- Document the additive-only scope in the README and fix the keycloak-config-cli link and the Docker example file location