### PR TITLE
Wire OS signals into the command context

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 )
@@ -18,10 +21,13 @@ func newRootCmd() *cobra.Command {
 }
 
 func Execute() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	rootCmd := newRootCmd()
 	rootCmd.AddCommand(newImportCmd())
 	rootCmd.AddCommand(newVersionCmd())
-	if err := rootCmd.Execute(); err != nil {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Seed the root command with a signal.NotifyContext so SIGINT/SIGTERM cancel the command context instead of killing the process immediately. This activates the existing ctx.Done() branches in the health-wait and OIDC discovery loops and cancels in-flight HTTP requests, allowing a graceful shutdown. A second signal still force-kills the process.